### PR TITLE
use default assignee only if category is not specified or it doesn't have a default assignee itself

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# ide files
+.idea

--- a/app/views/settings/_default_assign.erb
+++ b/app/views/settings/_default_assign.erb
@@ -40,14 +40,21 @@
    <%= check_box_tag('settings[interactive_assignment]', true, interactive_assignment) %>
  </p>
 
- <p><%= l(:self_assignment_explanation) %></p>
- <p>
-   <%= label('settings[self_assignment]', l(:self_assignment)) %>
-   <%-
-     self_assignment = @settings['self_assignment'] || 'false'
-     self_assignment = (self_assignment == 'true')
-   -%>
-   <%= hidden_field_tag('settings[self_assignment]', false) %>
-   <%= check_box_tag('settings[self_assignment]', true, self_assignment) %>
- </p>
+  <p><%= l(:self_assignment_explanation) %></p>
+  <p>
+    <%= label('settings[self_assignment]', l(:self_assignment)) %>
+    <%-
+      self_assignment = @settings['self_assignment'] || 'false'
+      self_assignment = (self_assignment == 'true')
+    -%>
+    <%= hidden_field_tag('settings[self_assignment]', false) %>
+    <%= check_box_tag('settings[self_assignment]', true, self_assignment) %>
+  </p>
+
+  <p>
+    <%= label 'settings[override_category_assignee]', l(:override_category_assignee, scope: :default_assign) %>
+    <%= hidden_field_tag('settings[override_category_assignee]', false) %>
+    <%= check_box_tag('settings[override_category_assignee]', true, @settings['override_category_assignee'] == 'true') %>
+    <%= content_tag :em, l(:override_category_assignee_info, scope: :default_assign), class: 'info' %>
+  </p>
 </fieldset>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -17,3 +17,6 @@ de:
     assignee set, tick the box below to assign the issue to the user who just
     created the issue, if possible. If the box is left unticked, there will be
     no assignee, which is the default behaviour in Redmine.
+  default_assign:
+    override_category_assignee_info: "Override Category Assignee"
+    override_category_assignee: "Override Category Assignee"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,7 +6,8 @@ en:
   interactive_assignment_explanation: >
     When creating a new issue, the plugin can populate the assignee with the
     default assignee you've chosen above, so that it'll be visible even before
-    you've created the issue. However, when you change certain fields, the form
+    you've created the issue. It works only if Override Category Assignee is enabled.
+    However, when you change certain fields, the form
     is reloaded and the default assignee is recalculated. This might be what you
     want, or it might be undesirable, so you can make the choice yourself:
   interactive_assignment: "Set Assignee Interactively"
@@ -18,3 +19,6 @@ en:
     assignee set, tick the box below to assign the issue to the user who just
     created the issue, if possible. If the box is left unticked, there will be
     no assignee, which is the default behaviour in Redmine.
+  default_assign:
+    override_category_assignee_info: "Override Category Assignee"
+    override_category_assignee: "Override Category Assignee"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -18,3 +18,6 @@ es:
     assignee set, tick the box below to assign the issue to the user who just
     created the issue, if possible. If the box is left unticked, there will be
     no assignee, which is the default behaviour in Redmine.
+  default_assign:
+    override_category_assignee_info: "Override Category Assignee"
+    override_category_assignee: "Override Category Assignee"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -20,3 +20,6 @@ fr:
     si-dessous pour tentir l'assignement de l'auteur de la demande. Sans
     sélection, il n'y aura aucun assignement pour la demande, ce qui est le
     comportement normal de Redmine.
+  default_assign:
+    override_category_assignee_info: "Override Category Assignee"
+    override_category_assignee: "Override Category Assignee"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -19,3 +19,6 @@ it:
     assignee set, tick the box below to assign the issue to the user who just
     created the issue, if possible. If the box is left unticked, there will be
     no assignee, which is the default behaviour in Redmine.
+  default_assign:
+    override_category_assignee_info: "Override Category Assignee"
+    override_category_assignee: "Override Category Assignee"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,3 +18,6 @@ ja:
     assignee set, tick the box below to assign the issue to the user who just
     created the issue, if possible. If the box is left unticked, there will be
     no assignee, which is the default behaviour in Redmine.
+  default_assign:
+    override_category_assignee_info: "Override Category Assignee"
+    override_category_assignee: "Override Category Assignee"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -18,3 +18,6 @@ ru:
     назначить задачу и если в проекте не выбрано на кого назначать по умолчанию,
     то задача будет назначена на автора задачи. Если этот пункт не выбран
     задача не будет ни на кого назначена - как сделано в Redmine по умолчанию.
+  default_assign:
+    override_category_assignee_info: "Override Category Assignee"
+    override_category_assignee: "Override Category Assignee"

--- a/lib/default_assign/hooks/default_assign_issues_hooks.rb
+++ b/lib/default_assign/hooks/default_assign_issues_hooks.rb
@@ -7,7 +7,9 @@ class DefaultAssignIssueHook < Redmine::Hook::ViewListener
     interactive_assignment =
       Setting.plugin_redmine_default_assign['interactive_assignment'] || 'true'
     interactive_assignment = (interactive_assignment == 'true')
-    return  if !interactive_assignment || Setting.plugin_redmine_default_assign[:override_category_assignee] != 'true'
+    return  if !interactive_assignment
+    # if interactive_assignment is true don't do anything if 'override category assignee' is false
+    return if Setting.plugin_redmine_default_assign[:override_category_assignee] != 'true'
 
     if context[:project].default_assignee.blank?
       self_assignment =

--- a/lib/default_assign/hooks/default_assign_issues_hooks.rb
+++ b/lib/default_assign/hooks/default_assign_issues_hooks.rb
@@ -7,7 +7,7 @@ class DefaultAssignIssueHook < Redmine::Hook::ViewListener
     interactive_assignment =
       Setting.plugin_redmine_default_assign['interactive_assignment'] || 'true'
     interactive_assignment = (interactive_assignment == 'true')
-    return  if not interactive_assignment
+    return  if !interactive_assignment || Setting.plugin_redmine_default_assign[:override_category_assignee] != 'true'
 
     if context[:project].default_assignee.blank?
       self_assignment =
@@ -22,5 +22,5 @@ class DefaultAssignIssueHook < Redmine::Hook::ViewListener
     end
 
     nil
-  end
+  end  
 end

--- a/lib/default_assign_issue_patch.rb
+++ b/lib/default_assign_issue_patch.rb
@@ -8,7 +8,7 @@ module DefaultAssignIssuePatch
     base.class_eval do
       unloadable # Send unloadable so it will not be unloaded in development
 
-      before_save :assign_default_assignee
+      before_create :assign_default_assignee
     end
   end
 

--- a/lib/default_assign_issue_patch.rb
+++ b/lib/default_assign_issue_patch.rb
@@ -6,16 +6,21 @@ module DefaultAssignIssuePatch
 
     # Same as typing in the class
     base.class_eval do
-      unloadable
+      unloadable # Send unloadable so it will not be unloaded in development
 
-      before_create :assign_default_assignee
+      before_save :assign_default_assignee
     end
   end
 
   module InstanceMethods
-    # If the issue isn't assigned to someone and a default assignee
-    # is set, set it.
+    # If the issue isn't assigned to someone and
+    # there isn't category's assignee with 'override category assignee' setting enabled
+    # and a default assignee is set,
+    # set it.
     def assign_default_assignee
+      return if category.present? && category.assigned_to.present? &&
+        Setting.plugin_redmine_default_assign[:override_category_assignee] != 'true'
+
       return  if not self.assigned_to.nil?
       default_assignee = self.project.default_assignee
       if default_assignee.blank?


### PR DESCRIPTION
https://github.com/giddie/redmine_default_assign/issues/30
use default assignee only if category is not specified or it doesn't have a default assignee itself